### PR TITLE
Address feedback

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -9,43 +9,65 @@ import (
 	"strings"
 )
 
+// Paths the server listens on.
+const (
+	helloPath = "/hello"
+	proxyPath = "/hello/proxy/"
+)
+
+// printHello writes the hello greeting to w.
 func printHello(w http.ResponseWriter) {
 	fmt.Fprintf(w, "Hello from Go\n")
 }
 
+// hello handles hello requests.
 func hello(w http.ResponseWriter, req *http.Request) {
 	printHello(w)
 }
 
-func proxyURL(orig *url.URL) *url.URL {
-	path := strings.TrimSuffix(orig.Path, "/")
-	idx := strings.LastIndex(path, "/")
-	return &url.URL{Scheme: "http", Host: path[idx+1:], Path: path[:idx]}
+// proxyURL returns a URL string for the next service to proxy a request to.
+//
+// The orig URL is assumed to be a proxy request URL that contain services
+// that need to be requested.
+func proxyURL(orig *url.URL) string {
+	u := &url.URL{Scheme: "http", Path: proxyPath}
+	services := strings.TrimPrefix(orig.Path, proxyPath)
+	switch parts := strings.SplitN(services, "/", 2); len(parts) {
+	case 2:
+		u.Path = u.Path + parts[1]
+		fallthrough
+	case 1:
+		u.Host = parts[0]
+	}
+	return u.String()
 }
 
+// proxy handles proxy requests.
 func proxy(w http.ResponseWriter, req *http.Request) {
 	defer printHello(w)
 
-	u := proxyURL(req.URL)
-	if u.Host == "proxy" {
-		// Handle the request to /hello/proxy/ directly."
+	if req.URL.Path == proxyPath {
 		return
 	}
-	resp, err := http.Get(u.String())
+
+	resp, err := http.Get(proxyURL(req.URL))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	defer resp.Body.Close()
 
-	io.Copy(w, resp.Body)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func main() {
+	// Do not include timestamps in log output.
 	log.SetFlags(0)
-	http.HandleFunc("/hello", hello)
-	http.HandleFunc("/hello/proxy", hello)
-	http.HandleFunc("/hello/proxy/", proxy)
+
+	http.HandleFunc(helloPath, hello)
+	http.HandleFunc(proxyPath, proxy)
 	if err := http.ListenAndServe(":80", nil); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
> [It doesn't matter too much, but I think the other implementations return a 400 for this request.](https://github.com/flands/otel-strangeloop-workshop/pull/1#discussion_r713551612)

> [I don't think it matters all that much, but I think the other implementations use the first segment after the /proxy/ to be the host to proxy to, rather than the last one. This is definitely simpler to implement. ;)](https://github.com/flands/otel-strangeloop-workshop/pull/1#discussion_r713552171)

Additionally comment functions and unify common strings.